### PR TITLE
Workaround to fix issue 52

### DIFF
--- a/inst/app/www/unavailable-times.js
+++ b/inst/app/www/unavailable-times.js
@@ -1,0 +1,33 @@
+$(function() {
+  /* 
+    Solves click issue.
+  */
+  // Do not 'check' null (no value) checkboxes when clicked
+  $('.noValue').on('click', () => false);
+
+  /*
+    Overkill way to solve issue when
+    space or enter is pressed after focusing 
+    on some cell(s) with null value,
+    even in multiselection case.
+  */
+  // For every handsontable table in the site,
+  // when any key is pressed into some
+  // handsontable table, convert its cells
+  // with value null into 'readOnly' type.
+  Handsontable.hooks.add('beforeKeyDown', function (e) {
+    var hot = this;
+    var data = hot.params.data;
+    hot.updateSettings({
+      cells(row, col) {
+        const cellProperties = {};
+              
+        if (data[row][col] === null) {
+          cellProperties.readOnly = true;
+        }
+
+        return cellProperties;
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #52.

I could not get rid of the checkboxes with unavailable times (null boxes), but this solution achieves the following:

- Null boxes do not change value when **clicked**.
- Null boxes do not change value when, after being in focus, the **Space** or **Enter** key is **pressed**.
- When **multiselecting** checkboxes and pressing space to select them, only the **non**-null boxes get selected.

A potential improvement may be to not focus on null boxes, when pressing the Tab key along the cells of the table,
but setting `tabindex="-1"` to each null box did not work. 
Such approach works for simple html tables, instead of ones created with handsontable.js,
independent of Shiny presence in the website.