### PR TITLE
Improve handling of unavailable times

### DIFF
--- a/inst/app/www/unavailable-times.js
+++ b/inst/app/www/unavailable-times.js
@@ -85,7 +85,7 @@ $(function() {
       var row = hot.getSelected()[0][0];
       var col = hot.getSelected()[0][1];
   
-      // Select 'closest next' cell with 
+      // Select 'closest previous' cell with 
       // non-null data, in case it exists
       var cellData = null;
       while (cellData === null) {

--- a/inst/app/www/unavailable-times.js
+++ b/inst/app/www/unavailable-times.js
@@ -30,4 +30,78 @@ $(function() {
       }
     });
   });
+
+  /*
+    When pressing Tab multiple times to change selected
+    cell in table (while not keeping pressed Shift) 
+    do not select the cells with null value,
+    such as the cells for unavailable times.
+  */
+  Handsontable.hooks.add('beforeKeyDown', function (event) {
+    if(!event.shiftKey && event.key === 'Tab') { 
+      var hot = this;
+      var numberOfRows = hot.countRows();
+      var numberOfColumns = hot.countCols();
+  
+      // Retrieve selected cell's indices (position) 
+      var row = hot.getSelected()[0][0];
+      var col = hot.getSelected()[0][1];
+  
+      // Select 'closest next' cell with 
+      // non-null data, in case it exists
+      var cellData = null;
+      while (cellData === null) {
+        if (col + 1 < numberOfColumns) {
+          col = col + 1;
+        } else if (row + 1 < numberOfRows) {
+          col = 0;
+          row = row + 1;
+        } else {
+          // Selected cell is the last one 
+          // (right lower corner of table)
+          return;
+        }
+        cellData = hot.getDataAtCell(row, col);
+      }
+      // setTimeout will be used in order to select
+      // a cell after the default behaviour after
+      // pressing Tab has occured.
+      setTimeout(() => hot.selectCell(row, col), 10);
+    }
+  });
+
+  /*
+    When pressing Tab multiple times to change selected
+    cell in table (while keeping pressed Shift) 
+    do not select the cells with null value,
+    such as the cells for unavailable times.
+  */
+  Handsontable.hooks.add('beforeKeyDown', function (event) {
+    if (event.shiftKey && event.key === 'Tab') {
+      var hot = this;
+      var numberOfColumns = hot.countCols();
+  
+      // Retrieve selected cell's indices (position) 
+      var row = hot.getSelected()[0][0];
+      var col = hot.getSelected()[0][1];
+  
+      // Select 'closest next' cell with 
+      // non-null data, in case it exists
+      var cellData = null;
+      while (cellData === null) {
+        if (col > 0) {
+          col = col - 1;
+        } else if (row > 0) {
+          col = numberOfColumns - 1;
+          row = row - 1;
+        } else {
+          // Selected cell is the first one 
+          // (left upper corner of table)
+          return;
+        }
+        cellData = hot.getDataAtCell(row, col);
+      }
+      setTimeout(() => hot.selectCell(row, col), 10);
+    }
+  });
 });


### PR DESCRIPTION
Before, when clicking on a checkbox from the table, the user could press Tab or Shift+Tab to quickly change focus between checkboxes, but it also selected cells corresponding to unavailable times.

Via this commit, such undesired selection dissapears.
Now, pressing Tab or Shift+Tab only changes selection between non null valued cells.