### PR TITLE
Use same service account format for bookclubber and bookclubdata.

### DIFF
--- a/.github/workflows/deploy_shinyapps.yml
+++ b/.github/workflows/deploy_shinyapps.yml
@@ -14,11 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up service account
-        run: |
-          echo '${{secrets.GOOGLE_SERVICE_ACCOUNT}}' >> inst/bookclubs4ds-service-account.json
-        shell: bash {0}
-
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.2.2'
@@ -29,6 +24,7 @@ jobs:
 
       - name: Set up .Renviron
         run: |
+          echo "R4DS_CLUB_GOOGLE_SERVICE_ACCOUNT=${{secrets.R4DS_CLUB_GOOGLE_SERVICE_ACCOUNT}}" >> .Renviron
           echo "shinyslack_key=${{secrets.SHINYSLACK_KEY}}" >> .Renviron
           echo "SLACK_SKIPLOAD=TRUE" >> .Renviron
         shell: bash {0}

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -13,11 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up service account
-        run: |
-          echo '${{secrets.GOOGLE_SERVICE_ACCOUNT}}' >> inst/bookclubs4ds-service-account.json
-        shell: bash {0}
-
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.2.2'
@@ -28,6 +23,7 @@ jobs:
 
       - name: Set up .Renviron
         run: |
+          echo "R4DS_CLUB_GOOGLE_SERVICE_ACCOUNT=${{secrets.R4DS_CLUB_GOOGLE_SERVICE_ACCOUNT}}" >> .Renviron
           echo "shinyslack_key=${{secrets.SHINYSLACK_KEY}}" >> .Renviron
           echo "SLACK_SKIPLOAD=TRUE" >> .Renviron
         shell: bash {0}

--- a/R/global.R
+++ b/R/global.R
@@ -13,13 +13,9 @@
   # Note that you must have the json named here in your inst folder. If you are
   # working on this app and believe you should be trusted with this access,
   # please contact the maintainer.
-  googlesheets4::gs4_auth(
-    path = .app_sys("bookclubs4ds-service-account.json")
-  )
+  .googledrive_authorize()
 
-  googledrive::drive_auth(
-    path = .app_sys("bookclubs4ds-service-account.json")
-  )
+  .googlesheets_authorize()
 }
 
 #' Check Club Sheet Modified Time

--- a/R/google.R
+++ b/R/google.R
@@ -1,0 +1,22 @@
+# Copy/pasting from bookclubdata until everything is transferred so everybody
+# uses the same service account format.
+
+.service_account_json <- function() {
+  intToUtf8(
+    base64enc::base64decode(
+      Sys.getenv("R4DS_CLUB_GOOGLE_SERVICE_ACCOUNT")
+    )
+  )
+}
+
+.googledrive_authorize <- function() {
+  googledrive::drive_auth(
+    path = .service_account_json()
+  )
+}
+
+.googlesheets_authorize <- function() {
+  googlesheets4::gs4_auth(
+    path = .service_account_json()
+  )
+}


### PR DESCRIPTION
Eventually only bookclubdata will "know" about the service account, although bookclubber will still need to pass it along to shinyapps.